### PR TITLE
Fix a tiny kinda-bug in PFMerge

### DIFF
--- a/redis/connection.go
+++ b/redis/connection.go
@@ -295,7 +295,7 @@ func (s *connection) PFCount(key string) (int, error) {
 
 func (s *connection) PFMerge(mergedKey string, keysToMerge ...string) (bool, error) {
 	result, err := redigo.String(s.Do("PFMERGE", redigo.Args{mergedKey}.AddFlat(keysToMerge)...))
-	if err != nil || err != ErrNil || result != "OK" {
+	if err != nil || err == ErrNil || result != "OK" {
 		return false, err
 	}
 	return true, nil

--- a/redis/connection_test.go
+++ b/redis/connection_test.go
@@ -10,6 +10,7 @@ import (
 
 var _ = Describe("Connection", func() {
 	c, _ := redis.NewConnection("redis://localhost:6379")
+
 	Describe("PFAdd", func() {
 		It("Should indicate HyperLogLog register was altered (ie: 1)", func() {
 			// Clean up the key
@@ -30,6 +31,7 @@ var _ = Describe("Connection", func() {
 			Expect(i).To(Equal(0))
 		})
 	})
+
 	Describe("PFCount", func() {
 		It("Should return the approximate cardinality of the HLL", func() {
 			c.Del("_tests:jimmy:redis:foo3")
@@ -43,6 +45,63 @@ var _ = Describe("Connection", func() {
 			// Check a VERY rough 20% accuracy
 			Expect(float64(card)).To(BeNumerically("<", actualCardinality*1.2))
 			Expect(float64(card)).To(BeNumerically(">", actualCardinality*(1-0.2)))
+		})
+	})
+
+	Describe("PFMerge", func() {
+		It("Should return the approximate cardinality of the union of multiple HLLs", func() {
+			c.Del("_tests:jimmy:redis:hll1")
+			c.Del("_tests:jimmy:redis:hll2")
+			c.Del("_tests:jimmy:redis:hll3")
+
+			setA := []int{1, 2, 3, 4, 5}
+			setB := []int{3, 4, 5, 6, 7}
+			setC := []int{8, 9, 10, 11, 12}
+
+			for _, x := range setA {
+				_, err := c.PFAdd("_tests:jimmy:redis:hll1", fmt.Sprint(x))
+				Expect(err).To(BeNil())
+			}
+
+			for _, x := range setB {
+				_, err := c.PFAdd("_tests:jimmy:redis:hll2", fmt.Sprint(x))
+				Expect(err).To(BeNil())
+			}
+
+			for _, x := range setC {
+				_, err := c.PFAdd("_tests:jimmy:redis:hll3", fmt.Sprint(x))
+				Expect(err).To(BeNil())
+			}
+
+			for i := 1; i < 4; i++ {
+				card, err := c.PFCount(fmt.Sprintf("_tests:jimmy:redis:hll%d", i))
+				Expect(err).To(BeNil())
+				Expect(card).To(Equal(5))
+			}
+
+			ok, err := c.PFMerge("_tests:jimmy:redis:hll1+2", "_tests:jimmy:redis:hll1", "_tests:jimmy:redis:hll2")
+			Expect(err).To(BeNil())
+			Expect(ok).To(BeTrue())
+
+			card, err := c.PFCount("_tests:jimmy:redis:hll1+2")
+			Expect(err).To(BeNil())
+			Expect(card).To(Equal(7))
+
+			ok, err = c.PFMerge("_tests:jimmy:redis:hll1+3", "_tests:jimmy:redis:hll1", "_tests:jimmy:redis:hll3")
+			Expect(err).To(BeNil())
+			Expect(ok).To(BeTrue())
+
+			card, err = c.PFCount("_tests:jimmy:redis:hll1+3")
+			Expect(err).To(BeNil())
+			Expect(card).To(Equal(10))
+
+			ok, err = c.PFMerge("_tests:jimmy:redis:hll1+2+3", "_tests:jimmy:redis:hll1", "_tests:jimmy:redis:hll2", "_tests:jimmy:redis:hll3")
+			Expect(err).To(BeNil())
+			Expect(ok).To(BeTrue())
+
+			card, err = c.PFCount("_tests:jimmy:redis:hll1+2+3")
+			Expect(err).To(BeNil())
+			Expect(card).To(Equal(12))
 		})
 	})
 })

--- a/redis/pipelined.go
+++ b/redis/pipelined.go
@@ -153,6 +153,10 @@ func (s *sendOnlyConnection) PFCount(key string) error {
 	return s.count(s.c.Send("PFCOUNT", key))
 }
 
+func (s *sendOnlyConnection) PFMerge(mergedKey string, keysToMerge ...string) error {
+	return s.count(s.c.Send("PFMERGE", redigo.Args{mergedKey}.AddFlat(keysToMerge)...))
+}
+
 // Pipeline - only visible to package
 
 func (s *sendOnlyConnection) receiveAll() ([]interface{}, error) {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -117,6 +117,7 @@ type NoResultCommands interface {
 
 	PFAdd(key string, values ...string) error
 	PFCount(key string) error
+	PFMerge(mergedKey string, keysToMerge ...string) error
 }
 
 type Transactions interface {


### PR DESCRIPTION
On success, PFmerge returns `false, nil` instead of `true, nil`. Also added interface for pipeline.

@kevin-cantwell 