### PR TITLE
Have ZAdd accept multiple args

### DIFF
--- a/redis/connection.go
+++ b/redis/connection.go
@@ -279,9 +279,9 @@ func (s *connection) SMove(source, destination, member string) (bool, error) {
 
 // SortedSetCommands
 
-func (s *connection) ZAdd(key string, score float64, value string) (int, error) {
+func (s *connection) ZAdd(key string, args ...interface{}) (int, error) {
 	// Returns number of elements added, 0 if already exist
-	return redigo.Int(s.Do("ZADD", key, score, value))
+	return redigo.Int(s.Do("ZADD", redigo.Args{key}.AddFlat(args)...))
 }
 
 func (s *connection) ZCard(key string) (int, error) {

--- a/redis/pipelined.go
+++ b/redis/pipelined.go
@@ -143,8 +143,8 @@ func (s *sendOnlyConnection) SDiff(key string, keys ...string) error {
 
 // SortedSetBatchCommands
 
-func (s *sendOnlyConnection) ZAdd(key string, score float64, value string) error {
-	return s.count(s.c.Send("ZADD", key, score, value))
+func (s *sendOnlyConnection) ZAdd(key string, args ...interface{}) error {
+	return s.count(s.c.Send("ZADD", redigo.Args{key}.AddFlat(args)...))
 }
 
 func (s *sendOnlyConnection) ZIncrBy(key string, score float64, value string) error {

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -532,14 +532,14 @@ func (s *pool) SMove(source, destination, member string) (bool, error) {
 
 // Commands - Sorted sets
 
-func (s *pool) ZAdd(key string, score float64, value string) (int, error) {
+func (s *pool) ZAdd(key string, args ...interface{}) (int, error) {
 	c, err := s.GetConnection()
 	if err != nil {
 		return 0, err
 	}
 	defer s.Return(c)
 
-	return c.ZAdd(key, score, value)
+	return c.ZAdd(key, args)
 }
 
 func (s *pool) ZCard(key string) (int, error) {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -137,7 +137,7 @@ type SetBatchCommands interface {
 
 // Sorted Sets - http://redis.io/commands#sorted_set
 type SortedSetCommands interface {
-	ZAdd(key string, score float64, value string) (int, error)
+	ZAdd(key string, args ...interface{}) (int, error)
 	ZCard(key string) (int, error)
 	ZRangeByScore(key, start, stop string, options ...interface{}) ([]string, error)
 	ZRangeByScoreWithLimit(key, start, stop string, offset, count int) ([]string, error)
@@ -147,7 +147,7 @@ type SortedSetCommands interface {
 }
 
 type SortedSetBatchCommands interface {
-	ZAdd(key string, score float64, value string) error
+	ZAdd(key string, args ...interface{}) error
 	ZIncrBy(key string, score float64, value string) error
 	ZRem(key string, members ...string) error
 }


### PR DESCRIPTION
Sending a bunch of members and their scores in a single command
can be _way_ faster than sending them one at a time.
