### PR TITLE
Default config to use a blocking pool of connections

### DIFF
--- a/redis/pool.go
+++ b/redis/pool.go
@@ -15,8 +15,9 @@ const Unlimited = 0
 var (
 	DefaultConfig = Config{
 		MaxOpenConnections: Unlimited,
-		MaxIdleConnections: 10,
-		IdleTimeout:        0,
+		MaxIdleConnections: 50,
+		IdleTimeout:        1 * time.Minute,
+		Wait:               true,
 	}
 
 	ErrPoolExhausted = errors.New("connection pool exhausted")
@@ -73,6 +74,7 @@ type Config struct {
 	MaxOpenConnections int
 	MaxIdleConnections int
 	IdleTimeout        time.Duration
+	Wait               bool
 }
 
 type PooledConnection interface {
@@ -116,6 +118,7 @@ func NewPoolWithURL(url *netURL.URL, config Config) Pool {
 	p := redigo.NewPool(generator, config.MaxIdleConnections)
 	p.MaxActive = config.MaxOpenConnections
 	p.IdleTimeout = config.IdleTimeout
+	p.Wait = config.Wait
 
 	return &pool{p: p, password: password}
 }


### PR DESCRIPTION
The ability to block on requests for a pooled connection from redigo has been available since [Nov 13th, 2014](https://github.com/garyburd/redigo/issues/56#ref-commit-54a2929). However, so far jimmy has hidden this ability from clients by abstracting away a subset of configuration options.

This change adds the configuration option `Wait` to the `Config` type and sets it when creating a new pool. It also changes the behavior of the `DefaultConfig` (used by most of our apps) to be a blocking pool with a pool-size of 50.

@bdotdub /cc @shenoybr @kjsteuer @jmw511 
